### PR TITLE
IOS-4905 Decrease interval

### DIFF
--- a/TangemSdk/TangemSdk/Common/NFC/NFCReader.swift
+++ b/TangemSdk/TangemSdk/Common/NFC/NFCReader.swift
@@ -216,7 +216,7 @@ extension NFCReader: CardReader {
                     Log.nfc("Restart polling interval is: \(interval)")
 
                     // 20 is too much because of time inaccuracy
-                    if interval >= 19 {
+                    if interval >= 18 {
                         Log.nfc("Ignore restart polling")
                         return
                     }


### PR DESCRIPTION
По результатам полевых тестов решили уменьшить до 18, потому что при сбросе к заводским, с 19 ошибка оставалась